### PR TITLE
Introduced integration tests using GH actions

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,4 +36,4 @@ jobs:
         run: distro/build/dist/bin/hz start > log.txt 2>&1 &
 
       - name: Check output
-        run: cat log.txt
+        run: sleep 30s && cat log.txt | grep "Members {size:1"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,4 +33,4 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI
-        run: distro/build/dist/bin/hz
+        run: distro/build/dist/bin/hz start

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI for IMDG
-        run: distro/build/dist/bin/hz start -x src/test/resources/integration-test-hazelcast.yaml &
+        run: distro/build/dist/bin/hz start -c src/test/resources/integration-test-hazelcast.yaml &
 
       - name: Check IMDG health
         run: |
@@ -50,7 +50,18 @@ jobs:
           done
 
       - name: Run CLI for MC
-        run: distro/build/dist/bin/hz mc start > log-mc.txt 2>&1 &
+        run: distro/build/dist/bin/hz mc start -J -Dhazelcast.mc.healthCheck.enable=true &
 
       - name: Check output
-        run: sleep 15s && cat log-mc.txt | grep "Hazelcast Management Center successfully started at"
+        run: |
+          attempts=0
+          max_attempts=10
+          until $(curl --output /dev/null --silent --fail "localhost:8080/health"); do
+            if [ ${attempts} -eq ${max_attempts} ];then
+                echo "Hazelcast MC not responding"
+                exit 1
+            fi
+            printf '.'
+            attempts=$(($attempts+1))
+            sleep 1
+          done

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,10 +33,21 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI for IMDG
-        run: distro/build/dist/bin/hz start -c src/test/resources/integration-test-hazelcast.yaml
+        run: distro/build/dist/bin/hz start -c src/test/resources/integration-test-hazelcast.yaml &
 
       - name: Check IMDG health
-        run: curl 127.0.0.1:5701/hazelcast/health/ready
+        run: |
+          attempts=0
+          max_attempts=10
+          until $(curl --fail "127.0.0.1:5701/hazelcast/health/ready"); do
+            if [ ${attempts} -eq ${max_attempts} ];then
+                echo "Hazelcast not responding"
+                exit 1
+            fi
+            printf '.'
+            attempts=$(($attempts+1))
+            sleep 1
+          done
 
       - name: Run CLI for MC
         run: distro/build/dist/bin/hz mc start > log-mc.txt 2>&1 &

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,33 @@
+name: integration-tests
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8' ]
+        architecture: [ 'x64' ]
+    name: Integration tests for CLI
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+          architecture: ${{ matrix.architecture }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Make
+        run: cd distro && make

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,8 +32,14 @@ jobs:
       - name: Make
         run: cd distro && make
 
-      - name: Run CLI
-        run: distro/build/dist/bin/hz start > log.txt 2>&1 &
+      - name: Run CLI for IMDG
+        run: distro/build/dist/bin/hz start > log-imdg.txt 2>&1 &
 
       - name: Check output
-        run: sleep 30s && cat log.txt | grep "Members {size:1"
+        run: sleep 15s && cat log-imdg.txt | grep "Members {size:1"
+
+      - name: Run CLI for MC
+        run: distro/build/dist/bin/hz mc start > log-mc.txt 2>&1 &
+
+      - name: Check output
+        run: sleep 15s && cat log-mc.txt | grep "Hazelcast Management Center successfully started at"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,10 +33,10 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI for IMDG
-        run: distro/build/dist/bin/hz start > log-imdg.txt 2>&1 &
+        run: distro/build/dist/bin/hz start -c src/test/resources/integration-test-hazelcast.yaml
 
-      - name: Check output
-        run: sleep 15s && cat log-imdg.txt | grep "Members {size:1"
+      - name: Check IMDG health
+        run: curl 127.0.0.1:5701/hazelcast/health/ready
 
       - name: Run CLI for MC
         run: distro/build/dist/bin/hz mc start > log-mc.txt 2>&1 &

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '8', '11' ]
         architecture: [ 'x64' ]
     name: Integration tests for CLI
     steps:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,5 +36,4 @@ jobs:
         run: distro/build/dist/bin/hz start > log.txt 2>&1 &
 
       - name: Check output
-        if: false == (cat log.txt | grep "Members {size:1")
-        run: exit 1
+        run: cat log.txt | grep "Members {size:1"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,4 +33,8 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI
-        run: distro/build/dist/bin/hz start
+        run: distro/build/dist/bin/hz start > log.txt 2>&1 &
+
+      - name: Check output
+        if: !(cat log.txt | grep "Members {size:1")
+        run: exit 1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,13 +33,13 @@ jobs:
         run: cd distro && make
 
       - name: Run CLI for IMDG
-        run: distro/build/dist/bin/hz start -c src/test/resources/integration-test-hazelcast.yaml &
+        run: distro/build/dist/bin/hz start -x src/test/resources/integration-test-hazelcast.yaml &
 
       - name: Check IMDG health
         run: |
           attempts=0
           max_attempts=10
-          until $(curl --fail "127.0.0.1:5701/hazelcast/health/ready"); do
+          until $(curl --silent --fail "127.0.0.1:5701/hazelcast/health/ready"); do
             if [ ${attempts} -eq ${max_attempts} ];then
                 echo "Hazelcast not responding"
                 exit 1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run CLI for MC
         run: distro/build/dist/bin/hz mc start -J -Dhazelcast.mc.healthCheck.enable=true &
 
-      - name: Check output
+      - name: Check MC health
         run: |
           attempts=0
           max_attempts=10

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,5 +36,5 @@ jobs:
         run: distro/build/dist/bin/hz start > log.txt 2>&1 &
 
       - name: Check output
-        if: !(cat log.txt | grep "Members {size:1")
+        if: false == (cat log.txt | grep "Members {size:1")
         run: exit 1

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Make
         run: cd distro && make
+
+      - name: Run CLI
+        run: distro/build/dist/bin/hz

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,4 +36,4 @@ jobs:
         run: distro/build/dist/bin/hz start > log.txt 2>&1 &
 
       - name: Check output
-        run: cat log.txt | grep "Members {size:1"
+        run: cat log.txt

--- a/src/test/resources/integration-test-hazelcast.yaml
+++ b/src/test/resources/integration-test-hazelcast.yaml
@@ -1,0 +1,14 @@
+hazelcast:
+  cluster-name: hz-it-cluster
+  properties:
+    hazelcast.socket.bind.any: false
+  network:
+    interfaces:
+      enabled: true
+      interfaces:
+        - 127.0.0.1
+    rest-api:
+      enabled: true
+      endpoint-groups:
+        HEALTH_CHECK:
+          enabled: true


### PR DESCRIPTION
Since we need an actual environment to test CLI with all its components, I introduced a GH action workflow. Right now, it runs on `ubuntu-latest` with JRE 8. Later on, we can also add other environments.