### PR TITLE
Fixed HAZELCAST_HOME symlink issue

### DIFF
--- a/distro/src/bin/hz
+++ b/distro/src/bin/hz
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
 
-# find the current directory and set the parent directory as HAZELCAST_HOME.
-PRGDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
+# find the current directory
+SCRIPT="$0"
+
+# if SCRIPT is a series of symbolic links; loop to get the concrete path
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+PRGDIR=`dirname "$SCRIPT"`
+# make PRGDIR absolute
+PRGDIR=`cd "$PRGDIR"; pwd`
+
+# set the parent directory as HAZELCAST_HOME.
 export HAZELCAST_HOME=${HAZELCAST_HOME:-$(cd "$PRGDIR/.." >/dev/null; pwd -P)}
 
 if [ $JAVA_HOME ] ; then


### PR DESCRIPTION
The existing `hz` script couldn't find the script's directory if it is run from a symlink. This PR fixes this problem without using non-standard `readlink` command.