### PR TITLE
Added a top level directory to the archive package

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This command prints Hazelcast IMDG, Management Center and the tool's version inf
 
 ```
 $ hz -V
-CLI tool: 4.2020.08
+CLI tool: 4.2020.08.1
 Hazelcast IMDG: 4.0.2
 Hazelcast Management Center: 4.2020.08
 ```

--- a/distro/Makefile
+++ b/distro/Makefile
@@ -54,6 +54,7 @@ get-artifacts: dist
 
 package:
 	# creating package
-	mkdir -p build/package
-	tar -zcf build/package/hazelcast-command-line-${CLI_VERSION}.tar.gz -C ${DIST} README.txt bin lib config artifacts
+	mkdir -p build/package/hazelcast-command-line-${CLI_VERSION}
+	cp -r ${DIST}/ build/package/hazelcast-command-line-${CLI_VERSION}
+	tar -zcf build/package/hazelcast-command-line-${CLI_VERSION}.tar.gz -C build/package hazelcast-command-line-${CLI_VERSION}
 	@echo "Archive build/package/hazelcast-command-line-${CLI_VERSION}.tar.gz created successfully"

--- a/distro/src/README.txt
+++ b/distro/src/README.txt
@@ -1,5 +1,3 @@
-hazelcast controls Hazelcast IMDG member instances
+Hazelcast Command Line is a tool which allows users to install & run Hazelcast IMDG and Management Center on local environment.
 
-Usage: hazelcast COMMAND
-
-Run 'hazelcast --help' for more information.
+Run 'hz --help' for more information.

--- a/distro/src/README.txt
+++ b/distro/src/README.txt
@@ -1,3 +1,3 @@
-Hazelcast Command Line is a tool which allows users to install & run Hazelcast IMDG and Management Center on local environment.
+Hazelcast Command Line is a tool that allows users to install & run Hazelcast IMDG and Management Center on the local environment.
 
 Run 'hz --help' for more information.


### PR DESCRIPTION
When extracting from the archive package, the contents are directly extracted to the current directory by default. To prevent this, a top level directory (`hazelcast-command-line-${CLI_VERSION}`) is added to the archive.

Requires update of the package manager implementations when released. 