### PR TITLE
Config file marking for DEB and RPM packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           tar -xvf ${{ env.ASSET_PATH }} -C packages/deb/hazelcast/usr/lib/hazelcast/
           ln -s /usr/lib/hazelcast/hazelcast-${{ env.HZ_VERSION }}/bin/hz packages/deb/hazelcast/usr/bin/hz
           sed -i 's+Version:.*$+Version: ${{ env.RELEASE }}+g' packages/deb/hazelcast/DEBIAN/control
+          sed -i 's+/usr/lib/hazelcast/hazelcast-.*/\(.*$\)+/usr/lib/hazelcast/hazelcast-${{ env.HZ_VERSION }}/bin/\1+g' packages/deb/hazelcast/DEBIAN/conffiles
           dpkg-deb --build packages/deb/hazelcast
           mv packages/deb/hazelcast.deb hazelcast-${{ env.RELEASE }}-all.deb
           curl --header "X-GPG-PASSPHRASE: ${{ secrets.BINTRAY_PASSPHRASE }}" -T hazelcast-${{ env.RELEASE }}-all.deb \

--- a/packages/deb/hazelcast/DEBIAN/conffiles
+++ b/packages/deb/hazelcast/DEBIAN/conffiles
@@ -1,0 +1,7 @@
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-client-failover-full-example.xml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-client-failover-full-example.yaml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-client-full-example.xml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-client-full-example.yaml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-full-example.xml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast-full-example.yaml
+/usr/lib/hazelcast/hazelcast-4.1-BETA-1/bin/hazelcast.xml

--- a/packages/rpm/hazelcast.spec
+++ b/packages/rpm/hazelcast.spec
@@ -44,8 +44,12 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %{_prefix}/lib/%{name}/%{name}-%{hzversion}/*
+%config(noreplace) %{_prefix}/lib/%{name}/%{name}-%{hzversion}/bin/*.xml
+%config(noreplace) %{_prefix}/lib/%{name}/%{name}-%{hzversion}/bin/*.yaml
 %{_bindir}/hz
 
 %changelog
+* Tue Oct 13 2020 Devops Hazelcast <devops@hazelcast.com> - 4.2020.10
+- Mark configuration files for upgrades
 * Tue Oct 13 2020 Devops Hazelcast <devops@hazelcast.com> - 4.2020.10
 - This is the initial RPM package spec

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-command-line</artifactId>
-    <version>4.2020.10</version>
+    <version>4.2020.10-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-command-line</artifactId>
-    <version>4.2020.10-SNAPSHOT</version>
+    <version>4.2020.10</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The configuration files are marked in DEB & RPM packages to prevent overwrite on upgrades/re-installs.